### PR TITLE
Corrige un bug lié à unreadForFeed

### DIFF
--- a/fleaditlater.plugin.disabled.php
+++ b/fleaditlater.plugin.disabled.php
@@ -33,7 +33,7 @@ function fleaditlater_plugin_displayEvents(&$myUser){
 								<a title="'.$data['link'].'" href="'.$data['link'].'" target="_blank">
 									'.Functions::truncate($data['title'],37).'
 								</a>
-								<button class="right unreadForFeed" onclick="fleadItLater('.$data['id'].',\'delete\',this)">
+								<button class="right" onclick="fleadItLater('.$data['id'].',\'delete\',this)">
 									<span title="'._t('P_FLEADITLATER_MARK_AS_READ').'" alt="'._t('P_FLEADITLATER_MARK_AS_READ').'">'._t('P_FLEADITLATER_MARK_AS_READ_SHORT').'</span>
 								</button>
 								</li>';


### PR DESCRIPTION
unreadForFeed est une classe utilisée pour détecter les flux. Cette
classe est associé à un événement sur click, demandant la confirmation
pour marquer les flux comme lus.

Actuellement, le message s'affiche avec un identifiant incorrect <null>
puisque le bouton ne concerne ici pas un flux.

Il faut vérifier s'il n'y a pas d'effet de bord à cette modification.